### PR TITLE
CSECURITY-15: Adding capability to read cache configs from store-config.yml.

### DIFF
--- a/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/internal/config/CacheEntry.java
+++ b/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/internal/config/CacheEntry.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.security.caas.internal.config;
+
+import org.wso2.carbon.security.caas.user.core.config.CacheConfig;
+
+/**
+ * Represents a CacheEntry in a store config.
+ */
+public class CacheEntry {
+
+    String name;
+    CacheConfig cacheConfig;
+    int size;
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public CacheConfig getCacheConfig() {
+        return cacheConfig;
+    }
+
+    public void setCacheConfig(CacheConfig cacheConfig) {
+        this.cacheConfig = cacheConfig;
+    }
+}

--- a/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/internal/config/StoreConfigBuilder.java
+++ b/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/internal/config/StoreConfigBuilder.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.security.caas.api.util.CarbonSecurityConstants;
 import org.wso2.carbon.security.caas.user.core.config.AuthorizationStoreConfig;
+import org.wso2.carbon.security.caas.user.core.config.CacheConfig;
 import org.wso2.carbon.security.caas.user.core.config.CredentialStoreConfig;
 import org.wso2.carbon.security.caas.user.core.config.IdentityStoreConfig;
 import org.wso2.carbon.security.caas.user.core.config.StoreConfig;
@@ -36,10 +37,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * Configuration builder for stores.
@@ -50,6 +53,11 @@ public class StoreConfigBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(StoreConfigBuilder.class);
 
+    /**
+     * Builder a config object based on the store-config.yml properties.
+     *
+     * @return StoreConfig
+     */
     public static StoreConfig buildStoreConfigs() {
 
         StoreConfig storeConfig = new StoreConfig();
@@ -79,7 +87,67 @@ public class StoreConfigBuilder {
                                                CarbonSecurityConstants.STORE_CONFIG_FILE);
         }
 
-        storeConfig.setEnableCache(storeConfigFile.isEnableCache());
+        boolean cacheEnabled = storeConfigFile.isEnableCache();
+        storeConfig.setEnableCache(cacheEnabled);
+
+        List<CacheEntry> credentialStoreCacheEntries = storeConfigFile.getCredentialStore().getCaches();
+        Map<String, CacheConfig> credentialStoreCacheConfigMap;
+
+        if (cacheEnabled && credentialStoreCacheEntries != null && !credentialStoreCacheEntries.isEmpty()) {
+            credentialStoreCacheConfigMap = credentialStoreCacheEntries.stream()
+                    .filter(t -> !(t.getName() == null || t.getName().isEmpty()))
+                    .map(t -> {
+                        if (t.getCacheConfig() == null) {
+                            t.setCacheConfig(new CacheConfig());
+                        }
+                        return t;
+                    })
+                    .collect(Collectors.toMap(CacheEntry::getName, CacheEntry::getCacheConfig));
+        } else {
+            credentialStoreCacheConfigMap = Collections.emptyMap();
+        }
+
+        storeConfig.setCredentialStoreCacheConfigMap(credentialStoreCacheConfigMap);
+
+        List<CacheEntry> identityStoreCacheEntries = storeConfigFile.getIdentityStore().getCaches();
+        Map<String, CacheConfig> identityStoreCacheConfigMap;
+
+        if (cacheEnabled && identityStoreCacheEntries != null && !identityStoreCacheEntries.isEmpty()) {
+
+            identityStoreCacheConfigMap = identityStoreCacheEntries.stream()
+                    .filter(t -> !(t.getName() == null || t.getName().isEmpty()))
+                    .map(t -> {
+                        if (t.getCacheConfig() == null) {
+                            t.setCacheConfig(new CacheConfig());
+                        }
+                        return t;
+                    })
+                    .collect(Collectors.toMap(CacheEntry::getName, CacheEntry::getCacheConfig));
+        } else {
+            identityStoreCacheConfigMap = Collections.emptyMap();
+        }
+
+        storeConfig.setIdentityStoreCacheConfigMap(identityStoreCacheConfigMap);
+
+        List<CacheEntry> authorizationStoreCacheEntries = storeConfigFile.getAuthorizationStore().getCaches();
+        Map<String, CacheConfig> authorizationStoreCacheConfigMap;
+
+        if (cacheEnabled && authorizationStoreCacheEntries != null && !authorizationStoreCacheEntries.isEmpty()) {
+
+            authorizationStoreCacheConfigMap = authorizationStoreCacheEntries.stream()
+                    .filter(t -> !(t.getName() == null || t.getName().isEmpty()))
+                    .map(t -> {
+                        if (t.getCacheConfig() == null) {
+                            t.setCacheConfig(new CacheConfig());
+                        }
+                        return t;
+                    })
+                    .collect(Collectors.toMap(CacheEntry::getName, CacheEntry::getCacheConfig));
+        } else {
+            authorizationStoreCacheConfigMap = Collections.emptyMap();
+        }
+
+        storeConfig.setAuthorizationStoreCacheConfigMap(authorizationStoreCacheConfigMap);
 
         if (storeConfigFile.getCredentialStore().getConnector() != null && !storeConfigFile.getCredentialStore()
                 .getConnector().trim().isEmpty()) {

--- a/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/internal/config/StoreConfigEntry.java
+++ b/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/internal/config/StoreConfigEntry.java
@@ -26,8 +26,8 @@ import java.util.Properties;
  */
 public class StoreConfigEntry {
 
-    //This variable represents whether cache should be enabled for a particular store. The default values is set to
-    //enableCache=true unless specified otherwise in the store-config file.
+    // This variable represents whether cache should be enabled for a particular store. The default values is set to
+    // enableCache=true unless specified otherwise in the store-config file.
     private boolean enableCache = true;
 
     private String connector;

--- a/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/internal/config/StoreConfigEntry.java
+++ b/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/internal/config/StoreConfigEntry.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.security.caas.internal.config;
 
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -25,11 +26,23 @@ import java.util.Properties;
  */
 public class StoreConfigEntry {
 
-    private boolean enableCache;
+    //This variable represents whether cache should be enabled for a particular store. The default values is set to
+    //enableCache=true unless specified otherwise in the store-config file.
+    private boolean enableCache = true;
 
     private String connector;
 
     private Properties properties;
+
+    private List<CacheEntry> caches;
+
+    public List<CacheEntry> getCaches() {
+        return caches;
+    }
+
+    public void setCaches(List<CacheEntry> cache) {
+        this.caches = cache;
+    }
 
     public boolean isEnableCache() {
         return enableCache;

--- a/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/user/core/config/CacheConfig.java
+++ b/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/user/core/config/CacheConfig.java
@@ -23,8 +23,9 @@ public class CacheConfig {
 
     private int expireTime;
     private int maxCapacity;
-    //Cache entries for a particular store should be enabled by default hence setting the value true by default so the
-    //cache config will always be enable=true if a value is not provided for a cache entry in store-config file.
+
+    // Cache entries for a particular store should be enabled by default hence setting the value true by default so the
+    // cache config will always be enable=true if a value is not provided for a cache entry in store-config file.
     private boolean enable = true;
     private boolean statisticsEnabled;
 

--- a/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/user/core/config/CacheConfig.java
+++ b/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/user/core/config/CacheConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.security.caas.user.core.config;
+
+/**
+ * Represents a cache config in the store config.
+ */
+public class CacheConfig {
+
+    private int expireTime;
+    private int maxCapacity;
+    //Cache entries for a particular store should be enabled by default hence setting the value true by default so the
+    //cache config will always be enable=true if a value is not provided for a cache entry in store-config file.
+    private boolean enable = true;
+    private boolean statisticsEnabled;
+
+    public int getMaxCapacity() {
+        return maxCapacity;
+    }
+
+    public void setMaxCapacity(int maxCapacity) {
+        this.maxCapacity = maxCapacity;
+    }
+
+    public boolean isStatisticsEnabled() {
+        return statisticsEnabled;
+    }
+
+    public void setStatisticsEnabled(boolean statisticsEnabled) {
+        this.statisticsEnabled = statisticsEnabled;
+    }
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+
+    public int getExpireTime() {
+        return expireTime;
+    }
+
+    public void setExpireTime(int expireTime) {
+        this.expireTime = expireTime;
+    }
+}

--- a/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/user/core/config/StoreConfig.java
+++ b/components/org.wso2.carbon.security.caas/src/main/java/org/wso2/carbon/security/caas/user/core/config/StoreConfig.java
@@ -31,6 +31,9 @@ public class StoreConfig {
     private Map<String, AuthorizationStoreConfig> authorizationStoreConfigMap = new HashMap<>();
     private Map<String, IdentityStoreConfig> identityStoreConfigMap = new HashMap<>();
     private Map<String, CredentialStoreConfig> credentialStoreConfigMap = new HashMap<>();
+    private Map<String, CacheConfig> authorizationStoreCacheConfigMap = new HashMap<>();
+    private Map<String, CacheConfig> identityStoreCacheConfigMap = new HashMap<>();
+    private Map<String, CacheConfig> credentialStoreCacheConfigMap = new HashMap<>();
 
     public boolean isEnableCache() {
         return enableCache;
@@ -98,5 +101,29 @@ public class StoreConfig {
 
     public void addCredentialStoreConfig(String name, CredentialStoreConfig credentialStoreConfig) {
         this.credentialStoreConfigMap.put(name, credentialStoreConfig);
+    }
+
+    public Map<String, CacheConfig> getAuthorizationStoreCacheConfigMap() {
+        return authorizationStoreCacheConfigMap;
+    }
+
+    public void setAuthorizationStoreCacheConfigMap(Map<String, CacheConfig> authorizationStoreCacheConfigMap) {
+        this.authorizationStoreCacheConfigMap = authorizationStoreCacheConfigMap;
+    }
+
+    public Map<String, CacheConfig> getIdentityStoreCacheConfigMap() {
+        return identityStoreCacheConfigMap;
+    }
+
+    public void setIdentityStoreCacheConfigMap(Map<String, CacheConfig> identityStoreCacheConfigMap) {
+        this.identityStoreCacheConfigMap = identityStoreCacheConfigMap;
+    }
+
+    public Map<String, CacheConfig> getCredentialStoreCacheConfigMap() {
+        return credentialStoreCacheConfigMap;
+    }
+
+    public void setCredentialStoreCacheConfigMap(Map<String, CacheConfig> cradentialStoreCacheConfigMap) {
+        this.credentialStoreCacheConfigMap = cradentialStoreCacheConfigMap;
     }
 }


### PR DESCRIPTION
Sample config for `store-config.yml`

``` yml
enableCache: true #optional. 'true' if not specified. Globally enable/disable caching across all stores. 
credentialStore:
 enableCache: true #optional. 'true' if not specified. enable/disable all caching within the store. 
 caches:
   -
    name: "cache_name_1" #mandatory for a caches entry. should provide a valid cache name.
    cacheConfig: #optional. Default configs will be assigned to the caches entry.
     maxCapacity: 100 #optional. If not specified, default system maxCapacity will be applied.
     expireTime: 10 #optional. If not specified, default system expiryTime will be applied. Unit: minutes.
     statisticsEnabled: false #optional. 'false' if not specified.
   -
    name: "cache_name_2"
    cacheConfig:
     expireTime: 10
     maxCapacity: 100
     statisticsEnabled: false
```
